### PR TITLE
Update gleam and dependency versions

### DIFF
--- a/examples/00-echo-bot/gleam.toml
+++ b/examples/00-echo-bot/gleam.toml
@@ -3,11 +3,11 @@ version = "1.0.0"
 description = "A Telega Echo Bot example"
 
 [dependencies]
-gleam_stdlib = "~> 0.34 or ~> 1.0"
-mist = "~> 1.2.0"
-gleam_erlang = "~> 0.25"
-wisp = "~> 0.14"
+gleam_stdlib = ">= 0.52.0 and < 1.0.0"
+gleam_erlang = ">= 0.33.0 and < 1.0.0"
+wisp = ">= 1.5.1 and < 2.0.0"
 telega = { path = "../.." }
+mist = ">= 4.0.4 and < 5.0.0"
 
 [dev-dependencies]
 gleeunit = "~> 1.0"

--- a/examples/00-echo-bot/src/bot.gleam
+++ b/examples/00-echo-bot/src/bot.gleam
@@ -7,6 +7,7 @@ import telega/adapters/wisp as telega_wisp
 import telega/reply
 import telega/update.{CommandUpdate, TextUpdate}
 import wisp
+import wisp/wisp_mist
 
 fn handle_request(bot, req) {
   use <- telega_wisp.handle_bot(req, bot)
@@ -38,7 +39,7 @@ pub fn main() {
     |> telega.init_nil_session
 
   let assert Ok(_) =
-    wisp.mist_handler(handle_request(bot, _), wisp.random_string(64))
+    wisp_mist.handler(handle_request(bot, _), wisp.random_string(64))
     |> mist.new
     |> mist.port(8000)
     |> mist.start_http

--- a/examples/01-commands-bot/gleam.toml
+++ b/examples/01-commands-bot/gleam.toml
@@ -3,12 +3,13 @@ version = "1.0.0"
 description = "A Telega Commands example"
 
 [dependencies]
-gleam_stdlib = "~> 0.34 or ~> 1.0"
-mist = "~> 1.2.0"
-gleam_erlang = "~> 0.25"
-wisp = "~> 0.14"
-dotenv_gleam = "1.0.5"
+gleam_stdlib = ">= 0.52.0 and < 1.0.0"
+mist = ">= 4.0.4 and < 5.0.0"
+gleam_erlang = ">= 0.33.0 and < 1.0.0"
+wisp = ">= 1.5.1 and < 2.0.0"
+dotenv_gleam = ">= 1.0.7 and < 2.0.0"
 telega = { path = "../.." }
+envoy = ">= 1.0.2 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = "~> 1.0"

--- a/examples/01-commands-bot/src/bot.gleam
+++ b/examples/01-commands-bot/src/bot.gleam
@@ -1,5 +1,5 @@
 import dotenv_gleam
-import gleam/erlang/os
+import envoy
 import gleam/erlang/process
 import gleam/option.{None, Some}
 import gleam/result
@@ -11,6 +11,7 @@ import telega/bot.{type Context}
 import telega/model as telega_model
 import telega/reply
 import wisp.{type Request, type Response}
+import wisp/wisp_mist
 
 type Bot =
   Telega(Nil)
@@ -65,10 +66,10 @@ fn start_command_handler(ctx: NilContext, _) -> Result(Nil, String) {
 }
 
 fn build_bot() {
-  let assert Ok(token) = os.get_env("BOT_TOKEN")
-  let assert Ok(webhook_path) = os.get_env("WEBHOOK_PATH")
-  let assert Ok(url) = os.get_env("SERVER_URL")
-  let assert Ok(secret_token) = os.get_env("BOT_SECRET_TOKEN")
+  let assert Ok(token) = envoy.get("BOT_TOKEN")
+  let assert Ok(webhook_path) = envoy.get("WEBHOOK_PATH")
+  let assert Ok(url) = envoy.get("SERVER_URL")
+  let assert Ok(secret_token) = envoy.get("BOT_SECRET_TOKEN")
 
   telega.new(token:, url:, webhook_path:, secret_token: Some(secret_token))
   |> telega.handle_command("dice", dice_command_handler)
@@ -83,11 +84,10 @@ pub fn main() {
   let assert Ok(bot) = build_bot()
   let secret_key_base = wisp.random_string(64)
   let assert Ok(_) =
-    wisp.mist_handler(handle_request(bot, _), secret_key_base)
+    wisp_mist.handler(handle_request(bot, _), secret_key_base)
     |> mist.new
     |> mist.port(8000)
     |> mist.start_http
-    |> result.nil_error
 
   process.sleep_forever()
   Ok(Nil)

--- a/examples/02-session-bot/gleam.toml
+++ b/examples/02-session-bot/gleam.toml
@@ -3,13 +3,14 @@ version = "1.0.0"
 description = "A Telega Session example"
 
 [dependencies]
-gleam_stdlib = "~> 0.34 or ~> 1.0"
-mist = "~> 1.2.0"
-gleam_erlang = "~> 0.25"
-wisp = "~> 0.14"
-dotenv_gleam = "1.0.5"
+gleam_stdlib = ">= 0.52.0 and < 1.0.0"
+mist = ">= 4.0.4 and < 5.0.0"
+gleam_erlang = ">= 0.33.0 and < 1.0.0"
+wisp = ">= 1.5.1 and < 2.0.0"
+dotenv_gleam = ">= 1.0.7 and < 2.0.0"
 telega = { path = "../.." }
-carpenter = "~> 0.3.1"
+carpenter = ">= 0.3.1 and < 1.0.0"
+envoy = ">= 1.0.2 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = "~> 1.0"

--- a/examples/02-session-bot/src/bot.gleam
+++ b/examples/02-session-bot/src/bot.gleam
@@ -1,6 +1,6 @@
 import dotenv_gleam
+import envoy
 import gleam/bool
-import gleam/erlang/os
 import gleam/erlang/process
 import gleam/option.{None, Some}
 import gleam/result
@@ -13,6 +13,7 @@ import telega/bot.{type Context}
 import telega/model as telega_model
 import telega/reply
 import wisp.{type Response}
+import wisp/wisp_mist
 
 type BotContext =
   Context(NameBotSession)
@@ -88,10 +89,10 @@ fn start_command_handler(ctx, _) -> Result(NameBotSession, String) {
 }
 
 fn build_bot() {
-  let assert Ok(token) = os.get_env("BOT_TOKEN")
-  let assert Ok(webhook_path) = os.get_env("WEBHOOK_PATH")
-  let assert Ok(url) = os.get_env("SERVER_URL")
-  let assert Ok(secret_token) = os.get_env("BOT_SECRET_TOKEN")
+  let assert Ok(token) = envoy.get("BOT_TOKEN")
+  let assert Ok(webhook_path) = envoy.get("WEBHOOK_PATH")
+  let assert Ok(url) = envoy.get("SERVER_URL")
+  let assert Ok(secret_token) = envoy.get("BOT_SECRET_TOKEN")
 
   telega.new(token:, url:, webhook_path:, secret_token: Some(secret_token))
   |> telega.handle_command("start", start_command_handler)
@@ -109,11 +110,10 @@ pub fn main() {
   let assert Ok(bot) = build_bot()
   let secret_key_base = wisp.random_string(64)
   let assert Ok(_) =
-    wisp.mist_handler(handle_request(bot, _), secret_key_base)
+    wisp_mist.handler(handle_request(bot, _), secret_key_base)
     |> mist.new
     |> mist.port(8000)
     |> mist.start_http
-    |> result.nil_error
 
   process.sleep_forever()
   Ok(Nil)

--- a/examples/03-conversation-bot/gleam.toml
+++ b/examples/03-conversation-bot/gleam.toml
@@ -3,13 +3,14 @@ version = "1.0.0"
 description = "A Telega Session example"
 
 [dependencies]
-gleam_stdlib = "~> 0.34 or ~> 1.0"
-mist = "~> 1.2.0"
-gleam_erlang = "~> 0.25"
-wisp = "~> 0.14"
-dotenv_gleam = "1.0.5"
+gleam_stdlib = ">= 0.52.0 and < 1.0.0"
+mist = ">= 4.0.4 and < 5.0.0"
+gleam_erlang = ">= 0.33.0 and < 1.0.0"
+wisp = ">= 1.5.1 and < 2.0.0"
+dotenv_gleam = ">= 1.0.7 and < 2.0.0"
 telega = { path = "../.." }
-carpenter = "~> 0.3.1"
+carpenter = ">= 0.3.1 and < 1.0.0"
+envoy = ">= 1.0.2 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = "~> 1.0"

--- a/examples/03-conversation-bot/src/bot.gleam
+++ b/examples/03-conversation-bot/src/bot.gleam
@@ -1,5 +1,5 @@
 import dotenv_gleam
-import gleam/erlang/os
+import envoy
 import gleam/erlang/process
 import gleam/option.{None, Some}
 import gleam/result
@@ -12,6 +12,7 @@ import telega/bot.{type Context}
 import telega/model as telega_model
 import telega/reply
 import wisp.{type Response}
+import wisp/wisp_mist
 
 type BotContext =
   Context(NameBotSession)
@@ -77,10 +78,10 @@ fn start_command_handler(ctx, _) -> Result(NameBotSession, String) {
 }
 
 fn build_bot() {
-  let assert Ok(token) = os.get_env("BOT_TOKEN")
-  let assert Ok(webhook_path) = os.get_env("WEBHOOK_PATH")
-  let assert Ok(url) = os.get_env("SERVER_URL")
-  let assert Ok(secret_token) = os.get_env("BOT_SECRET_TOKEN")
+  let assert Ok(token) = envoy.get("BOT_TOKEN")
+  let assert Ok(webhook_path) = envoy.get("WEBHOOK_PATH")
+  let assert Ok(url) = envoy.get("SERVER_URL")
+  let assert Ok(secret_token) = envoy.get("BOT_SECRET_TOKEN")
 
   telega.new(token:, url:, webhook_path:, secret_token: Some(secret_token))
   |> telega.handle_command("start", start_command_handler)
@@ -97,11 +98,10 @@ pub fn main() {
   let assert Ok(bot) = build_bot()
   let secret_key_base = wisp.random_string(64)
   let assert Ok(_) =
-    wisp.mist_handler(handle_request(bot, _), secret_key_base)
+    wisp_mist.handler(handle_request(bot, _), secret_key_base)
     |> mist.new
     |> mist.port(8000)
     |> mist.start_http
-    |> result.nil_error
 
   process.sleep_forever()
   Ok(Nil)

--- a/examples/04-keyboard-bot/gleam.toml
+++ b/examples/04-keyboard-bot/gleam.toml
@@ -3,13 +3,14 @@ version = "1.0.0"
 description = "A Telega Session example"
 
 [dependencies]
-gleam_stdlib = "~> 0.34 or ~> 1.0"
-mist = "~> 1.2.0"
-gleam_erlang = "~> 0.25"
-wisp = "~> 0.14"
-dotenv_gleam = "1.0.5"
+gleam_stdlib = ">= 0.52.0 and < 1.0.0"
+mist = ">= 4.0.4 and < 5.0.0"
+gleam_erlang = ">= 0.33.0 and < 1.0.0"
+wisp = ">= 1.5.1 and < 2.0.0"
+dotenv_gleam = ">= 1.0.7 and < 2.0.0"
 telega = { path = "../.." }
-carpenter = "~> 0.3.1"
+carpenter = ">= 0.3.1 and < 1.0.0"
+envoy = ">= 1.0.2 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = "~> 1.0"

--- a/examples/04-keyboard-bot/src/bot.gleam
+++ b/examples/04-keyboard-bot/src/bot.gleam
@@ -1,5 +1,5 @@
 import dotenv_gleam
-import gleam/erlang/os
+import envoy
 import gleam/erlang/process
 import gleam/option.{None, Some}
 import gleam/result
@@ -14,6 +14,7 @@ import telega/keyboard as telega_keyboard
 import telega/model.{EditMessageTextParameters, Stringed} as telega_model
 import telega/reply
 import wisp.{type Response}
+import wisp/wisp_mist
 
 type BotContext =
   Context(LanguageBotSession)
@@ -142,10 +143,10 @@ fn start_command_handler(
 }
 
 fn build_bot() {
-  let assert Ok(token) = os.get_env("BOT_TOKEN")
-  let assert Ok(webhook_path) = os.get_env("WEBHOOK_PATH")
-  let assert Ok(url) = os.get_env("SERVER_URL")
-  let assert Ok(secret_token) = os.get_env("BOT_SECRET_TOKEN")
+  let assert Ok(token) = envoy.get("BOT_TOKEN")
+  let assert Ok(webhook_path) = envoy.get("WEBHOOK_PATH")
+  let assert Ok(url) = envoy.get("SERVER_URL")
+  let assert Ok(secret_token) = envoy.get("BOT_SECRET_TOKEN")
 
   telega.new(token:, url:, webhook_path:, secret_token: Some(secret_token))
   |> telega.handle_command("start", start_command_handler)
@@ -162,11 +163,10 @@ pub fn main() {
   let assert Ok(bot) = build_bot()
   let secret_key_base = wisp.random_string(64)
   let assert Ok(_) =
-    wisp.mist_handler(handle_request(bot, _), secret_key_base)
+    wisp_mist.handler(handle_request(bot, _), secret_key_base)
     |> mist.new
     |> mist.port(8000)
     |> mist.start_http
-    |> result.nil_error
 
   process.sleep_forever()
   Ok(Nil)

--- a/gleam.toml
+++ b/gleam.toml
@@ -5,22 +5,23 @@ licences = ["Apache-2.0"]
 repository = { type = "github", user = "bondiano", repo = "telega-gleam" }
 links = [
     { title = "Issues", href = "https://github.com/bondiano/telega-gleam/issues" },
-    { title = "Examples", href = "https://github.com/bondiano/telega-gleam/tree/master/examples"}
+    { title = "Examples", href = "https://github.com/bondiano/telega-gleam/tree/master/examples" },
 ]
 
-gleam = ">= 0.32.0"
+gleam = ">= 1.7.0"
 target = "erlang"
 
 [dependencies]
-gleam_stdlib = "~> 0.39"
-logging = "~> 1.0"
-gleam_http = "~> 3.6"
-gleam_httpc = "~> 2.2"
-wisp = "~> 0.14"
-gleam_json = "~> 1.0"
-gleam_erlang = "~> 0.25"
-gleam_otp = "~> 0.10"
+gleam_stdlib = ">= 0.52.0 and < 1.0.0"
+logging = ">= 1.3.0 and < 2.0.0"
+gleam_http = ">= 3.7.2 and < 4.0.0"
+gleam_httpc = ">= 4.0.0 and < 5.0.0"
+wisp = ">= 1.5.1 and < 2.0.0"
+gleam_erlang = ">= 0.33.0 and < 1.0.0"
+gleam_otp = ">= 0.16.0 and < 1.0.0"
+gleam_json = ">= 2.3.0 and < 3.0.0"
+gleam_regexp = ">= 1.0.0 and < 2.0.0"
 
 [dev-dependencies]
-gleeunit = "~> 1.0"
-mockth = "0.3.2"
+gleeunit = ">= 1.2.0 and < 2.0.0"
+mockth = ">= 0.4.0 and < 1.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,39 +2,43 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "birl", version = "1.7.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "ranger"], otp_app = "birl", source = "hex", outer_checksum = "5C66647D62BCB11FE327E7A6024907C4A17954EF22865FE0940B54A852446D01" },
+  { name = "directories", version = "1.1.0", build_tools = ["gleam"], requirements = ["envoy", "gleam_stdlib", "platform", "simplifile"], otp_app = "directories", source = "hex", outer_checksum = "BDA521A4EB9EE3A7894F0DC863797878E91FF5C7826F7084B2E731E208BDB076" },
+  { name = "envoy", version = "1.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "envoy", source = "hex", outer_checksum = "95FD059345AA982E89A0B6E2A3BF1CF43E17A7048DCD85B5B65D3B9E4E39D359" },
   { name = "exception", version = "2.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "F5580D584F16A20B7FCDCABF9E9BE9A2C1F6AC4F9176FA6DD0B63E3B20D450AA" },
-  { name = "filepath", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "EFB6FF65C98B2A16378ABC3EE2B14124168C0CE5201553DE652E2644DCFDB594" },
-  { name = "gleam_crypto", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "ADD058DEDE8F0341F1ADE3AAC492A224F15700829D9A3A3F9ADF370F875C51B7" },
-  { name = "gleam_erlang", version = "0.25.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "054D571A7092D2A9727B3E5D183B7507DAB0DA41556EC9133606F09C15497373" },
-  { name = "gleam_http", version = "3.6.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "8C07DF9DF8CC7F054C650839A51C30A7D3C26482AC241C899C1CEA86B22DBE51" },
-  { name = "gleam_httpc", version = "2.2.0", build_tools = ["gleam"], requirements = ["gleam_http", "gleam_stdlib"], otp_app = "gleam_httpc", source = "hex", outer_checksum = "CF76C71002DEECF6DC5D9CA83D962728FAE166B57926BE442D827004D3C7DF1B" },
-  { name = "gleam_json", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "thoas"], otp_app = "gleam_json", source = "hex", outer_checksum = "9063D14D25406326C0255BDA0021541E797D8A7A12573D849462CAFED459F6EB" },
-  { name = "gleam_otp", version = "0.10.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "0B04FE915ACECE539B317F9652CAADBBC0F000184D586AAAF2D94C100945D72B" },
-  { name = "gleam_stdlib", version = "0.39.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "2D7DE885A6EA7F1D5015D1698920C9BAF7241102836CE0C3837A4F160128A9C4" },
+  { name = "filepath", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "67A6D15FB39EEB69DD31F8C145BB5A421790581BD6AA14B33D64D5A55DBD6587" },
+  { name = "gleam_crypto", version = "1.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "8AE56026B3E05EBB1F076778478A762E9EB62B31AEEB4285755452F397029D22" },
+  { name = "gleam_erlang", version = "0.33.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "A1D26B80F01901B59AABEE3475DD4C18D27D58FA5C897D922FCB9B099749C064" },
+  { name = "gleam_http", version = "3.7.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "8A70D2F70BB7CFEB5DF048A2183FFBA91AF6D4CF5798504841744A16999E33D2" },
+  { name = "gleam_httpc", version = "4.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_http", "gleam_stdlib"], otp_app = "gleam_httpc", source = "hex", outer_checksum = "76FEEC99473E568EBA34336A37CF3D54629ACE77712950DC9BB097B5FD664664" },
+  { name = "gleam_json", version = "2.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "C55C5C2B318533A8072D221C5E06E5A75711C129E420DD1CE463342106012E5D" },
+  { name = "gleam_otp", version = "0.16.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "FA0EB761339749B4E82D63016C6A18C4E6662DA05BAB6F1346F9AF2E679E301A" },
+  { name = "gleam_regexp", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "A3655FDD288571E90EE9C4009B719FEF59FA16AFCDF3952A76A125AF23CF1592" },
+  { name = "gleam_stdlib", version = "0.52.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "50703862DF26453B277688FFCDBE9DD4AC45B3BD9742C0B370DB62BC1629A07D" },
+  { name = "gleam_yielder", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_yielder", source = "hex", outer_checksum = "8E4E4ECFA7982859F430C57F549200C7749823C106759F4A19A78AEA6687717A" },
   { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
-  { name = "glisten", version = "2.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib"], otp_app = "glisten", source = "hex", outer_checksum = "CF3A9383E9BA4A8CBAF2F7B799716290D02F2AC34E7A77556B49376B662B9314" },
-  { name = "gramps", version = "2.0.3", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib"], otp_app = "gramps", source = "hex", outer_checksum = "3CCAA6E081225180D95C79679D383BBF51C8D1FDC1B84DA1DA444F628C373793" },
+  { name = "glisten", version = "7.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib", "logging", "telemetry"], otp_app = "glisten", source = "hex", outer_checksum = "028C0882EAC7ABEDEFBE92CE4D1FEDADE95FA81B1B1AB099C4F91C133BEF2C42" },
+  { name = "gramps", version = "3.0.0", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib"], otp_app = "gramps", source = "hex", outer_checksum = "630BDE35E465511945253A06EBCDE8D5E4B8B1988F4AC6B8FAC297DEF55B4CA2" },
   { name = "hpack_erl", version = "0.3.0", build_tools = ["rebar3"], requirements = [], otp_app = "hpack", source = "hex", outer_checksum = "D6137D7079169D8C485C6962DFE261AF5B9EF60FBC557344511C1E65E3D95FB0" },
-  { name = "logging", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "logging", source = "hex", outer_checksum = "FCB111401BDB4703A440A94FF8CC7DA521112269C065F219C2766998333E7738" },
-  { name = "marceau", version = "1.2.0", build_tools = ["gleam"], requirements = [], otp_app = "marceau", source = "hex", outer_checksum = "5188D643C181EE350D8A20A3BDBD63AF7B6C505DE333CFBE05EF642ADD88A59B" },
+  { name = "logging", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "logging", source = "hex", outer_checksum = "1098FBF10B54B44C2C7FDF0B01C1253CAFACDACABEFB4B0D027803246753E06D" },
+  { name = "marceau", version = "1.3.0", build_tools = ["gleam"], requirements = [], otp_app = "marceau", source = "hex", outer_checksum = "2D1C27504BEF45005F5DFB18591F8610FB4BFA91744878210BDC464412EC44E9" },
   { name = "meck", version = "0.9.2", build_tools = ["rebar3"], requirements = [], otp_app = "meck", source = "hex", outer_checksum = "81344F561357DC40A8344AFA53767C32669153355B626EA9FCBC8DA6B3045826" },
-  { name = "mist", version = "1.2.0", build_tools = ["gleam"], requirements = ["birl", "gleam_erlang", "gleam_http", "gleam_otp", "gleam_stdlib", "glisten", "gramps", "hpack_erl", "logging"], otp_app = "mist", source = "hex", outer_checksum = "109B4D64E68C104CC23BB3CC5441ECD479DD7444889DA01113B75C6AF0F0E17B" },
-  { name = "mockth", version = "0.3.2", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib", "meck"], otp_app = "mockth", source = "hex", outer_checksum = "00BED139504EC09A6840F9F11717F9206167C4DF2E8BE722798BD32EA43349B4" },
-  { name = "ranger", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "ranger", source = "hex", outer_checksum = "1566C272B1D141B3BBA38B25CB761EF56E312E79EC0E2DFD4D3C19FB0CC1F98C" },
-  { name = "simplifile", version = "2.0.1", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "5FFEBD0CAB39BDD343C3E1CCA6438B2848847DC170BA2386DF9D7064F34DF000" },
-  { name = "thoas", version = "1.2.1", build_tools = ["rebar3"], requirements = [], otp_app = "thoas", source = "hex", outer_checksum = "E38697EDFFD6E91BD12CEA41B155115282630075C2A727E7A6B2947F5408B86A" },
-  { name = "wisp", version = "0.15.0", build_tools = ["gleam"], requirements = ["exception", "gleam_crypto", "gleam_erlang", "gleam_http", "gleam_json", "gleam_stdlib", "logging", "marceau", "mist", "simplifile"], otp_app = "wisp", source = "hex", outer_checksum = "33D17A50276FE0A10E4F694E4EF7D99836954DC2D920D4B5741B1E0EBCAE403F" },
+  { name = "mist", version = "4.0.4", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_http", "gleam_otp", "gleam_stdlib", "gleam_yielder", "glisten", "gramps", "hpack_erl", "logging"], otp_app = "mist", source = "hex", outer_checksum = "9F87DA535A75AA1B8B37D27E59B1E60A1BE34EB2CA63BE8B211D75E5D10BEEAF" },
+  { name = "mockth", version = "0.4.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib", "gleeunit", "meck"], otp_app = "mockth", source = "hex", outer_checksum = "5C74302233E587E6E5AAF6D4E6943B37C2C7CB2FC2220AB4263999F7FECD0FA3" },
+  { name = "platform", version = "1.0.0", build_tools = ["gleam"], requirements = [], otp_app = "platform", source = "hex", outer_checksum = "8339420A95AD89AAC0F82F4C3DB8DD401041742D6C3F46132A8739F6AEB75391" },
+  { name = "simplifile", version = "2.2.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "0DFABEF7DC7A9E2FF4BB27B108034E60C81BEBFCB7AB816B9E7E18ED4503ACD8" },
+  { name = "telemetry", version = "1.3.0", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "7015FC8919DBE63764F4B4B87A95B7C0996BD539E0D499BE6EC9D7F3875B79E6" },
+  { name = "wisp", version = "1.5.1", build_tools = ["gleam"], requirements = ["directories", "exception", "gleam_crypto", "gleam_erlang", "gleam_http", "gleam_json", "gleam_stdlib", "logging", "marceau", "mist", "simplifile"], otp_app = "wisp", source = "hex", outer_checksum = "DB7968F777CA77B41AAC8067A5151B022E857E1EECF16BFC9D5F914D0F628844" },
 ]
 
 [requirements]
-gleam_erlang = { version = "~> 0.25" }
-gleam_http = { version = "~> 3.6" }
-gleam_httpc = { version = "~> 2.2" }
-gleam_json = { version = "~> 1.0" }
-gleam_otp = { version = "~> 0.10" }
-gleam_stdlib = { version = "~> 0.39" }
-gleeunit = { version = "~> 1.0" }
-logging = { version = "~> 1.0" }
-mockth = { version = "0.3.2" }
-wisp = { version = "~> 0.14" }
+gleam_erlang = { version = ">= 0.33.0 and < 1.0.0" }
+gleam_http = { version = ">= 3.7.2 and < 4.0.0" }
+gleam_httpc = { version = ">= 4.0.0 and < 5.0.0" }
+gleam_json = { version = ">= 2.3.0 and < 3.0.0" }
+gleam_otp = { version = ">= 0.16.0 and < 1.0.0" }
+gleam_regexp = { version = ">= 1.0.0 and < 2.0.0" }
+gleam_stdlib = { version = ">= 0.52.0 and < 1.0.0" }
+gleeunit = { version = ">= 1.2.0 and < 2.0.0" }
+logging = { version = ">= 1.3.0 and < 2.0.0" }
+mockth = { version = ">= 0.4.0 and < 1.0.0" }
+wisp = { version = ">= 1.5.1 and < 2.0.0" }

--- a/src/telega.gleam
+++ b/src/telega.gleam
@@ -87,10 +87,10 @@ pub fn handle_command(
   command command: String,
   handler handler: fn(Context(session), Command) -> Result(session, String),
 ) -> TelegaBuilder(session) {
-  TelegaBuilder(
-    ..builder,
-    handlers: [HandleCommand(command, handler), ..builder.handlers],
-  )
+  TelegaBuilder(..builder, handlers: [
+    HandleCommand(command, handler),
+    ..builder.handlers
+  ])
 }
 
 pub fn wait_command(
@@ -107,10 +107,10 @@ pub fn handle_commands(
   commands commands: List(String),
   handler handler: fn(Context(session), Command) -> Result(session, String),
 ) -> TelegaBuilder(session) {
-  TelegaBuilder(
-    ..builder,
-    handlers: [HandleCommands(commands, handler), ..builder.handlers],
-  )
+  TelegaBuilder(..builder, handlers: [
+    HandleCommands(commands, handler),
+    ..builder.handlers
+  ])
 }
 
 pub fn wait_commands(
@@ -142,10 +142,10 @@ pub fn handle_hears(
   hears hears: Hears,
   handler handler: fn(Context(session), String) -> Result(session, String),
 ) -> TelegaBuilder(session) {
-  TelegaBuilder(
-    ..builder,
-    handlers: [HandleHears(hears, handler), ..builder.handlers],
-  )
+  TelegaBuilder(..builder, handlers: [
+    HandleHears(hears, handler),
+    ..builder.handlers
+  ])
 }
 
 pub fn wait_hears(
@@ -163,10 +163,10 @@ pub fn handle_callback_query(
   handler handler: fn(Context(session), String, String) ->
     Result(session, String),
 ) -> TelegaBuilder(session) {
-  TelegaBuilder(
-    ..builder,
-    handlers: [HandleCallbackQuery(filter, handler), ..builder.handlers],
-  )
+  TelegaBuilder(..builder, handlers: [
+    HandleCallbackQuery(filter, handler),
+    ..builder.handlers
+  ])
 }
 
 pub fn wait_callback_query(

--- a/src/telega/adapters/wisp.gleam
+++ b/src/telega/adapters/wisp.gleam
@@ -3,6 +3,7 @@ import gleam/http/request
 import gleam/http/response.{Response as HttpResponse}
 import gleam/result
 import telega.{type Telega}
+
 import telega/log
 import telega/update
 import wisp.{
@@ -37,9 +38,10 @@ pub fn handle_bot(
 
   case update.decode(json) {
     Ok(message) -> {
-      use <- bool.lazy_guard(is_secret_token_valid(telega, req), fn() {
-        HttpResponse(401, [], WispEmptyBody)
-      })
+      use <- bool.lazy_guard(
+        when: !is_secret_token_valid(telega, req),
+        return: fn() { HttpResponse(401, [], WispEmptyBody) },
+      )
       case telega.handle_update(telega, message) {
         Ok(_) -> wisp.ok()
         Error(error) -> {

--- a/src/telega/api.gleam
+++ b/src/telega/api.gleam
@@ -449,7 +449,7 @@ fn send_with_retry(
   let response = httpc.send(api_request)
 
   case retries {
-    0 -> response
+    0 -> response |> result.map_error(dynamic.from)
     _ -> {
       case response {
         Ok(response) -> {

--- a/src/telega/bot.gleam
+++ b/src/telega/bot.gleam
@@ -6,7 +6,7 @@ import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/otp/actor
 import gleam/otp/supervisor
-import gleam/regex.{type Regex}
+import gleam/regexp.{type Regexp}
 import gleam/result
 import gleam/string
 import telega/api
@@ -342,16 +342,16 @@ fn handle_bot_instanse_message(
 pub type Hears {
   HearText(text: String)
   HearTexts(texts: List(String))
-  HearRegex(regex: Regex)
-  HearRegexes(regexes: List(Regex))
+  HearRegex(regex: Regexp)
+  HearRegexes(regexes: List(Regexp))
 }
 
 fn hears_check(text: String, hear: Hears) -> Bool {
   case hear {
     HearText(str) -> text == str
     HearTexts(strs) -> list.contains(strs, text)
-    HearRegex(re) -> regex.check(re, text)
-    HearRegexes(regexes) -> list.any(regexes, regex.check(_, text))
+    HearRegex(re) -> regexp.check(re, text)
+    HearRegexes(regexes) -> list.any(regexes, regexp.check(_, text))
   }
 }
 
@@ -383,7 +383,7 @@ pub type Handler(session) {
 }
 
 pub type CallbackQueryFilter {
-  CallbackQueryFilter(re: Regex)
+  CallbackQueryFilter(re: Regexp)
 }
 
 fn do_handle(
@@ -416,7 +416,7 @@ fn do_handle(
     HandleCallbackQuery(filter, handle), CallbackQueryUpdate(raw: raw, ..) ->
       case raw.data {
         Some(data) ->
-          case regex.check(filter.re, data) {
+          case regexp.check(filter.re, data) {
             True -> Some(handle(new_context(bot, update), data, raw.id))
             False -> None
           }

--- a/src/telega/keyboard.gleam
+++ b/src/telega/keyboard.gleam
@@ -2,7 +2,7 @@
 
 import gleam/list
 import gleam/option.{type Option, None, Some}
-import gleam/regex
+import gleam/regexp
 import gleam/result
 import gleam/string
 import telega/bot.{
@@ -141,7 +141,7 @@ pub fn filter_inline_keyboard_query(
     |> option.values
     |> string.join("|")
 
-  let assert Ok(re) = regex.from_string("^(" <> options <> ")$")
+  let assert Ok(re) = regexp.from_string("^(" <> options <> ")$")
 
   CallbackQueryFilter(re)
 }

--- a/src/telega/model.gleam
+++ b/src/telega/model.gleam
@@ -384,7 +384,7 @@ pub fn decode_message(json: Dynamic) -> Result(Message, dynamic.DecodeErrors) {
       is_from_offline
     ->
       Error(
-        list.concat([
+        list.flatten([
           all_errors(message_id),
           all_errors(message_thread_id),
           all_errors(from),

--- a/src/telega/update.gleam
+++ b/src/telega/update.gleam
@@ -107,7 +107,7 @@ fn extract_command(text: String) -> Command {
     [command, ..payload] ->
       Command(
         text:,
-        command: string.drop_left(command, 1),
+        command: string.drop_start(command, 1),
         payload: payload
           |> string.join(" ")
           |> Some,


### PR DESCRIPTION
I've updated gleam to v1.7.0, updated the standard library and dependencies, and replaced deprecated functions. I've also added `envoy` to the examples for getting environment variables as gleam/erlang/os environment functions have been removed.