### PR TITLE
Expand API by adding new commands

### DIFF
--- a/examples/01-commands-bot/src/bot.gleam
+++ b/examples/01-commands-bot/src/bot.gleam
@@ -48,18 +48,28 @@ fn dice_command_handler(ctx: NilContext, _) -> Result(Nil, String) {
   |> result.map(fn(_) { Nil })
 }
 
+fn poll_command_handler(ctx: NilContext, _) -> Result(Nil, String) {
+  use <- telega.log_context(ctx, "poll")
+
+  reply.with_poll(ctx, "What is your favorite color?", ["Red", "Green", "Blue"])
+  |> result.map(fn(_) { Nil })
+}
+
 fn start_command_handler(ctx: NilContext, _) -> Result(Nil, String) {
   use <- telega.log_context(ctx, "start")
 
   telega_api.set_my_commands(
     ctx.config.api,
-    telega_model.bot_commands_from([#("/dice", "Roll a dice")]),
+    telega_model.bot_commands_from([
+      #("/dice", "Roll a dice"),
+      #("/poll", "Start a poll"),
+    ]),
     None,
   )
   |> result.then(fn(_) {
     reply.with_text(
       ctx,
-      "Hello! I'm a dice bot. You can roll a dice by sending /dice command.",
+      "Hello! I'm a dice bot. You can roll a dice by sending /dice command or start a poll by sending the /poll command.",
     )
     |> result.map(fn(_) { Nil })
   })
@@ -73,6 +83,7 @@ fn build_bot() {
 
   telega.new(token:, url:, webhook_path:, secret_token: Some(secret_token))
   |> telega.handle_command("dice", dice_command_handler)
+  |> telega.handle_command("poll", poll_command_handler)
   |> telega.handle_command("start", start_command_handler)
   |> telega.init_nil_session
 }

--- a/src/telega.gleam
+++ b/src/telega.gleam
@@ -293,3 +293,7 @@ pub fn handle_update(
     HandleBotRegistryMessage(update: update),
   ))
 }
+
+pub fn get_api_config(telega: Telega(session)) -> api.TelegramApiConfig {
+  telega.config.api
+}

--- a/src/telega/api.gleam
+++ b/src/telega/api.gleam
@@ -270,6 +270,25 @@ pub fn send_poll(
   |> map_resonse(model.decode_message)
 }
 
+/// Use this method to send invoices.
+///
+/// **Official reference:** https://core.telegram.org/bots/api#sendinvoice
+pub fn send_invoice(
+  config config: TelegramApiConfig,
+  parameters parameters: model.SendInvoiceParameters,
+) -> Result(ModelMessage, String) {
+  let body_json = model.encode_send_invoice_parameters(parameters)
+
+  new_post_request(
+    config,
+    path: "sendInvoice",
+    body: json.to_string(body_json),
+    query: None,
+  )
+  |> fetch(config)
+  |> map_resonse(model.decode_message)
+}
+
 /// A simple method for testing your bot's authentication token.
 ///
 /// **Official reference:** https://core.telegram.org/bots/api#getme

--- a/src/telega/api.gleam
+++ b/src/telega/api.gleam
@@ -251,6 +251,25 @@ pub fn send_dice(
   |> map_resonse(model.decode_message)
 }
 
+///  Use this method to send a native poll.
+///
+/// **Official reference:** https://core.telegram.org/bots/api#sendpoll
+pub fn send_poll(
+  config config: TelegramApiConfig,
+  parameters parameters: model.SendPollParameters,
+) -> Result(ModelMessage, String) {
+  let body_json = model.encode_send_poll_parameters(parameters)
+
+  new_post_request(
+    config,
+    path: "sendPoll",
+    body: json.to_string(body_json),
+    query: None,
+  )
+  |> fetch(config)
+  |> map_resonse(model.decode_message)
+}
+
 /// A simple method for testing your bot's authentication token.
 ///
 /// **Official reference:** https://core.telegram.org/bots/api#getme

--- a/src/telega/api.gleam
+++ b/src/telega/api.gleam
@@ -289,6 +289,25 @@ pub fn send_invoice(
   |> map_resonse(model.decode_message)
 }
 
+/// Use this method to create a link for an invoice.
+///
+/// **Official reference:** https://core.telegram.org/bots/api#createinvoicelink
+pub fn create_invoice_link(
+  config config: TelegramApiConfig,
+  parameters parameters: model.CreateInvoiceLinkParameters,
+) -> Result(String, String) {
+  let body_json = model.encode_create_invoice_link_parameters(parameters)
+
+  new_post_request(
+    config,
+    path: "createInvoiceLink",
+    body: json.to_string(body_json),
+    query: None,
+  )
+  |> fetch(config)
+  |> map_resonse(dynamic.string)
+}
+
 /// A simple method for testing your bot's authentication token.
 ///
 /// **Official reference:** https://core.telegram.org/bots/api#getme

--- a/src/telega/model.gleam
+++ b/src/telega/model.gleam
@@ -2368,6 +2368,281 @@ pub fn encode_forward_message_parameters(
   ])
 }
 
+// SendInvoice ---------------------------------------------------------------------------
+
+pub type LabeledPrice {
+  LabeledPrice(label: String, amount: Int)
+}
+
+pub fn encode_labeled_price(labeled_price labeled_price: LabeledPrice) -> Json {
+  json_object_filter_nulls([
+    #("label", json.string(labeled_price.label)),
+    #("amount", json.int(labeled_price.amount)),
+  ])
+}
+
+pub type SendInvoiceParameters {
+  SendInvoiceParameters(
+    /// Unique identifier for the target chat or username of the target channel (in the format `@channelusername`)
+    chat_id: IntOrString,
+    /// Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
+    message_thread_id: Option(Int),
+    /// Product name, 1-32 characters
+    title: String,
+    /// Product description, 1-255 characters
+    description: String,
+    /// Bot-defined invoice payload, 1-128 bytes. This will not be displayed to the user, use it for your internal processes
+    payload: String,
+    /// Payment provider token, obtained via @BotFather. Pass an empty string for payments in Telegram Stars
+    provider_token: Option(String),
+    /// Three-letter ISO 4217 currency code, see more on currencies. Pass “XTR” for payments in Telegram Stars
+    currency: String,
+    /// Price breakdown, a JSON-serialized list of components. Must contain exactly one item for payments in Telegram Stars
+    prices: List(LabeledPrice),
+    /// The maximum accepted amount for tips in the smallest units of the currency. Defaults to 0. Not supported for payments in Telegram Stars
+    max_tip_amount: Option(Int),
+    /// A JSON-serialized array of suggested amounts of tips in the smallest units of the currency. At most 4 suggested tip amounts can be specified
+    suggested_tip_amounts: Option(List(Int)),
+    /// Unique deep-linking parameter. If non-empty, forwarded copies will have a URL button with a deep link to the bot
+    start_parameter: Option(String),
+    /// JSON-serialized data about the invoice, which will be shared with the payment provider
+    provider_data: Option(String),
+    /// URL of the product photo for the invoice
+    photo_url: Option(String),
+    /// Photo size in bytes
+    photo_size: Option(Int),
+    /// Photo width
+    photo_width: Option(Int),
+    /// Photo height
+    photo_height: Option(Int),
+    /// Pass True if you require the user's full name to complete the order. Ignored for payments in Telegram Stars
+    need_name: Option(Bool),
+    /// Pass True if you require the user's phone number to complete the order. Ignored for payments in Telegram Stars
+    need_phone_number: Option(Bool),
+    /// Pass True if you require the user's email address to complete the order. Ignored for payments in Telegram Stars
+    need_email: Option(Bool),
+    /// Pass True if you require the user's shipping address to complete the order. Ignored for payments in Telegram Stars
+    need_shipping_address: Option(Bool),
+    /// Pass True if the user's phone number should be sent to the provider. Ignored for payments in Telegram Stars
+    send_phone_number_to_provider: Option(Bool),
+    /// Pass True if the user's email address should be sent to the provider. Ignored for payments in Telegram Stars
+    send_email_to_provider: Option(Bool),
+    /// Pass True if the final price depends on the shipping method. Ignored for payments in Telegram Stars
+    is_flexible: Option(Bool),
+    /// Sends the message silently. Users will receive a notification with no sound
+    disable_notification: Option(Bool),
+    /// Protects the contents of the sent message from forwarding and saving
+    protect_content: Option(Bool),
+    /// Pass True to allow up to 1000 messages per second, ignoring broadcasting limits for a fee of 0.1 Telegram Stars per message
+    allow_paid_broadcast: Option(Bool),
+    /// Unique identifier of the message effect to be added to the message; for private chats only
+    message_effect_id: Option(String),
+    /// Description of the message to reply to
+    reply_parameters: Option(ReplyParameters),
+    /// A JSON-serialized object for an inline keyboard. If empty, one 'Pay total price' button will be shown
+    reply_markup: Option(InlineKeyboardMarkup),
+  )
+}
+
+pub fn new_send_invoice_parameters(
+  chat_id chat_id: IntOrString,
+  title title: String,
+  description description: String,
+  payload payload: String,
+  currency currency: String,
+  prices prices: List(#(String, Int)),
+) -> SendInvoiceParameters {
+  SendInvoiceParameters(
+    chat_id: chat_id,
+    message_thread_id: None,
+    title: title,
+    description: description,
+    payload: payload,
+    provider_token: None,
+    currency: currency,
+    prices: list.map(prices, fn(price) {
+      LabeledPrice(label: price.0, amount: price.1)
+    }),
+    max_tip_amount: None,
+    suggested_tip_amounts: None,
+    start_parameter: None,
+    provider_data: None,
+    photo_url: None,
+    photo_size: None,
+    photo_width: None,
+    photo_height: None,
+    need_name: None,
+    need_phone_number: None,
+    need_email: None,
+    need_shipping_address: None,
+    send_phone_number_to_provider: None,
+    send_email_to_provider: None,
+    is_flexible: None,
+    disable_notification: None,
+    protect_content: None,
+    allow_paid_broadcast: None,
+    message_effect_id: None,
+    reply_parameters: None,
+    reply_markup: None,
+  )
+}
+
+pub fn encode_send_invoice_parameters(
+  send_invoice_parameters: SendInvoiceParameters,
+) -> Json {
+  let chat_id = #(
+    "chat_id",
+    encode_int_or_string(send_invoice_parameters.chat_id),
+  )
+  let message_thread_id = #(
+    "message_thread_id",
+    json.nullable(send_invoice_parameters.message_thread_id, json.int),
+  )
+  let title = #("title", json.string(send_invoice_parameters.title))
+  let description = #(
+    "description",
+    json.string(send_invoice_parameters.description),
+  )
+  let payload = #("payload", json.string(send_invoice_parameters.payload))
+  let provider_token = #(
+    "provider_token",
+    json.nullable(send_invoice_parameters.provider_token, json.string),
+  )
+  let currency = #("currency", json.string(send_invoice_parameters.currency))
+  let prices = #(
+    "prices",
+    json.array(send_invoice_parameters.prices, encode_labeled_price),
+  )
+  let max_tip_amount = #(
+    "max_tip_amount",
+    json.nullable(send_invoice_parameters.max_tip_amount, json.int),
+  )
+  let suggested_tip_amounts = #(
+    "suggested_tip_amounts",
+    json.nullable(send_invoice_parameters.suggested_tip_amounts, json.array(
+      _,
+      json.int,
+    )),
+  )
+  let start_parameter = #(
+    "start_parameter",
+    json.nullable(send_invoice_parameters.start_parameter, json.string),
+  )
+  let provider_data = #(
+    "provider_data",
+    json.nullable(send_invoice_parameters.provider_data, json.string),
+  )
+  let photo_url = #(
+    "photo_url",
+    json.nullable(send_invoice_parameters.photo_url, json.string),
+  )
+  let photo_size = #(
+    "photo_size",
+    json.nullable(send_invoice_parameters.photo_size, json.int),
+  )
+  let photo_width = #(
+    "photo_width",
+    json.nullable(send_invoice_parameters.photo_width, json.int),
+  )
+  let photo_height = #(
+    "photo_height",
+    json.nullable(send_invoice_parameters.photo_height, json.int),
+  )
+  let need_name = #(
+    "need_name",
+    json.nullable(send_invoice_parameters.need_name, json.bool),
+  )
+  let need_phone_number = #(
+    "need_phone_number",
+    json.nullable(send_invoice_parameters.need_phone_number, json.bool),
+  )
+  let need_email = #(
+    "need_email",
+    json.nullable(send_invoice_parameters.need_email, json.bool),
+  )
+  let need_shipping_address = #(
+    "need_shipping_address",
+    json.nullable(send_invoice_parameters.need_shipping_address, json.bool),
+  )
+  let send_phone_number_to_provider = #(
+    "send_phone_number_to_provider",
+    json.nullable(
+      send_invoice_parameters.send_phone_number_to_provider,
+      json.bool,
+    ),
+  )
+  let send_email_to_provider = #(
+    "send_email_to_provider",
+    json.nullable(send_invoice_parameters.send_email_to_provider, json.bool),
+  )
+  let is_flexible = #(
+    "is_flexible",
+    json.nullable(send_invoice_parameters.is_flexible, json.bool),
+  )
+  let disable_notification = #(
+    "disable_notification",
+    json.nullable(send_invoice_parameters.disable_notification, json.bool),
+  )
+  let protect_content = #(
+    "protect_content",
+    json.nullable(send_invoice_parameters.protect_content, json.bool),
+  )
+  let allow_paid_broadcast = #(
+    "allow_paid_broadcast",
+    json.nullable(send_invoice_parameters.allow_paid_broadcast, json.bool),
+  )
+  let message_effect_id = #(
+    "message_effect_id",
+    json.nullable(send_invoice_parameters.message_effect_id, json.string),
+  )
+  let reply_parameters = #(
+    "reply_parameters",
+    json.nullable(
+      send_invoice_parameters.reply_parameters,
+      encode_reply_parameters,
+    ),
+  )
+  let reply_markup = #(
+    "reply_markup",
+    json.nullable(
+      send_invoice_parameters.reply_markup,
+      encode_inline_keyboard_markup,
+    ),
+  )
+
+  json_object_filter_nulls([
+    chat_id,
+    message_thread_id,
+    title,
+    description,
+    payload,
+    provider_token,
+    currency,
+    prices,
+    max_tip_amount,
+    suggested_tip_amounts,
+    start_parameter,
+    provider_data,
+    photo_url,
+    photo_size,
+    photo_width,
+    photo_height,
+    need_name,
+    need_phone_number,
+    need_email,
+    need_shipping_address,
+    send_phone_number_to_provider,
+    send_email_to_provider,
+    is_flexible,
+    disable_notification,
+    protect_content,
+    allow_paid_broadcast,
+    message_effect_id,
+    reply_parameters,
+    reply_markup,
+  ])
+}
+
 // AnswerCallbackQueryParameters --------------------------------------------------------------------------------------
 // https://core.telegram.org/bots/api#answercallbackquery
 pub type AnswerCallbackQueryParameters {

--- a/src/telega/model.gleam
+++ b/src/telega/model.gleam
@@ -2643,6 +2643,222 @@ pub fn encode_send_invoice_parameters(
   ])
 }
 
+// CreateInvoiceLink ---------------------------------------------------------------------------
+
+pub type CreateInvoiceLinkParameters {
+  CreateInvoiceLinkParameters(
+    /// Unique identifier of the business connection on behalf of which the link will be created. For payments in Telegram Stars only.
+    business_connection_id: Option(String),
+    /// Product name, 1-32 characters
+    title: String,
+    /// Product description, 1-255 characters
+    description: String,
+    /// Bot-defined invoice payload, 1-128 bytes. This will not be displayed to the user, use it for your internal processes
+    payload: String,
+    /// Payment provider token, obtained via @BotFather. Pass an empty string for payments in Telegram Stars
+    provider_token: Option(String),
+    /// Three-letter ISO 4217 currency code, see more on currencies. Pass “XTR” for payments in Telegram Stars
+    currency: String,
+    /// Price breakdown, a JSON-serialized list of components (e.g. product price, tax, discount, delivery cost, delivery tax, bonus, etc.). Must contain exactly one item for payments in Telegram Stars
+    prices: List(LabeledPrice),
+    /// The number of seconds the subscription will be active for before the next payment. The currency must be set to “XTR” (Telegram Stars) if the parameter is used. Currently, it must always be 2592000 (30 days) if specified. Any number of subscriptions can be active for a given bot at the same time, including multiple concurrent subscriptions from the same user. Subscription price must not exceed 2500 Telegram Stars
+    subscription_period: Option(Int),
+    /// The maximum accepted amount for tips in the smallest units of the currency. Defaults to 0. Not supported for payments in Telegram Stars
+    max_tip_amount: Option(Int),
+    /// A JSON-serialized array of suggested amounts of tips in the smallest units of the currency. At most 4 suggested tip amounts can be specified
+    suggested_tip_amounts: Option(List(Int)),
+    /// JSON-serialized data about the invoice, which will be shared with the payment provider
+    provider_data: Option(String),
+    /// URL of the product photo for the invoice. Can be a photo of the goods or a marketing image for a service
+    photo_url: Option(String),
+    /// Photo size in bytes
+    photo_size: Option(Int),
+    /// Photo width
+    photo_width: Option(Int),
+    /// Photo height
+    photo_height: Option(Int),
+    /// Pass True if you require the user's full name to complete the order. Ignored for payments in Telegram Stars
+    need_name: Option(Bool),
+    /// Pass True if you require the user's phone number to complete the order. Ignored for payments in Telegram Stars
+    need_phone_number: Option(Bool),
+    /// Pass True if you require the user's email address to complete the order. Ignored for payments in Telegram Stars
+    need_email: Option(Bool),
+    /// Pass True if you require the user's shipping address to complete the order. Ignored for payments in Telegram Stars
+    need_shipping_address: Option(Bool),
+    /// Pass True if the user's phone number should be sent to the provider. Ignored for payments in Telegram Stars
+    send_phone_number_to_provider: Option(Bool),
+    /// Pass True if the user's email address should be sent to the provider. Ignored for payments in Telegram Stars
+    send_email_to_provider: Option(Bool),
+    /// Pass True if the final price depends on the shipping method. Ignored for payments in Telegram Stars
+    is_flexible: Option(Bool),
+  )
+}
+
+pub fn new_create_invoice_link_parameters(
+  title title: String,
+  description description: String,
+  payload payload: String,
+  currency currency: String,
+  prices prices: List(#(String, Int)),
+) -> CreateInvoiceLinkParameters {
+  CreateInvoiceLinkParameters(
+    business_connection_id: None,
+    title: title,
+    description: description,
+    payload: payload,
+    provider_token: None,
+    currency: currency,
+    prices: list.map(prices, fn(price) {
+      LabeledPrice(label: price.0, amount: price.1)
+    }),
+    subscription_period: None,
+    max_tip_amount: None,
+    suggested_tip_amounts: None,
+    provider_data: None,
+    photo_url: None,
+    photo_size: None,
+    photo_width: None,
+    photo_height: None,
+    need_name: None,
+    need_phone_number: None,
+    need_email: None,
+    need_shipping_address: None,
+    send_phone_number_to_provider: None,
+    send_email_to_provider: None,
+    is_flexible: None,
+  )
+}
+
+pub fn encode_create_invoice_link_parameters(
+  create_invoice_link_parameters: CreateInvoiceLinkParameters,
+) -> Json {
+  let business_connection_id = #(
+    "business_connection_id",
+    json.nullable(
+      create_invoice_link_parameters.business_connection_id,
+      json.string,
+    ),
+  )
+  let title = #("title", json.string(create_invoice_link_parameters.title))
+  let description = #(
+    "description",
+    json.string(create_invoice_link_parameters.description),
+  )
+  let payload = #(
+    "payload",
+    json.string(create_invoice_link_parameters.payload),
+  )
+  let provider_token = #(
+    "provider_token",
+    json.nullable(create_invoice_link_parameters.provider_token, json.string),
+  )
+  let currency = #(
+    "currency",
+    json.string(create_invoice_link_parameters.currency),
+  )
+  let prices = #(
+    "prices",
+    json.array(create_invoice_link_parameters.prices, encode_labeled_price),
+  )
+  let subscription_period = #(
+    "subscription_period",
+    json.nullable(create_invoice_link_parameters.subscription_period, json.int),
+  )
+  let max_tip_amount = #(
+    "max_tip_amount",
+    json.nullable(create_invoice_link_parameters.max_tip_amount, json.int),
+  )
+  let suggested_tip_amounts = #(
+    "suggested_tip_amounts",
+    json.nullable(
+      create_invoice_link_parameters.suggested_tip_amounts,
+      json.array(_, json.int),
+    ),
+  )
+  let provider_data = #(
+    "provider_data",
+    json.nullable(create_invoice_link_parameters.provider_data, json.string),
+  )
+  let photo_url = #(
+    "photo_url",
+    json.nullable(create_invoice_link_parameters.photo_url, json.string),
+  )
+  let photo_size = #(
+    "photo_size",
+    json.nullable(create_invoice_link_parameters.photo_size, json.int),
+  )
+  let photo_width = #(
+    "photo_width",
+    json.nullable(create_invoice_link_parameters.photo_width, json.int),
+  )
+  let photo_height = #(
+    "photo_height",
+    json.nullable(create_invoice_link_parameters.photo_height, json.int),
+  )
+  let need_name = #(
+    "need_name",
+    json.nullable(create_invoice_link_parameters.need_name, json.bool),
+  )
+  let need_phone_number = #(
+    "need_phone_number",
+    json.nullable(create_invoice_link_parameters.need_phone_number, json.bool),
+  )
+  let need_email = #(
+    "need_email",
+    json.nullable(create_invoice_link_parameters.need_email, json.bool),
+  )
+  let need_shipping_address = #(
+    "need_shipping_address",
+    json.nullable(
+      create_invoice_link_parameters.need_shipping_address,
+      json.bool,
+    ),
+  )
+  let send_phone_number_to_provider = #(
+    "send_phone_number_to_provider",
+    json.nullable(
+      create_invoice_link_parameters.send_phone_number_to_provider,
+      json.bool,
+    ),
+  )
+  let send_email_to_provider = #(
+    "send_email_to_provider",
+    json.nullable(
+      create_invoice_link_parameters.send_email_to_provider,
+      json.bool,
+    ),
+  )
+  let is_flexible = #(
+    "is_flexible",
+    json.nullable(create_invoice_link_parameters.is_flexible, json.bool),
+  )
+
+  json_object_filter_nulls([
+    business_connection_id,
+    title,
+    description,
+    payload,
+    provider_token,
+    currency,
+    prices,
+    subscription_period,
+    max_tip_amount,
+    suggested_tip_amounts,
+    provider_data,
+    photo_url,
+    photo_size,
+    photo_width,
+    photo_height,
+    need_name,
+    need_phone_number,
+    need_email,
+    need_shipping_address,
+    send_phone_number_to_provider,
+    send_email_to_provider,
+    is_flexible,
+  ])
+}
+
 // AnswerCallbackQueryParameters --------------------------------------------------------------------------------------
 // https://core.telegram.org/bots/api#answercallbackquery
 pub type AnswerCallbackQueryParameters {

--- a/src/telega/model.gleam
+++ b/src/telega/model.gleam
@@ -701,6 +701,10 @@ pub type SendMessageParameters {
     disable_notification: Option(Bool),
     /// Protects the contents of the sent message from forwarding and saving
     protect_content: Option(Bool),
+    ///  Pass True to allow up to 1000 messages per second, ignoring broadcasting limits for a fee of 0.1 Telegram Stars per message. The relevant Stars will be withdrawn from the bot's balance
+    allow_paid_broadcast: Option(Bool),
+    /// Unique identifier of the message effect to be added to the message; for private chats only
+    message_effect_id: Option(String),
     /// Description of the message to reply to
     reply_parameters: Option(ReplyParameters),
     /// Additional interface options. A JSON-serialized object for an [inline keyboard](https://core.telegram.org/bots/features#inline-keyboards), [custom reply keyboard](https://core.telegram.org/bots/features#keyboards), instructions to remove a reply keyboard or to force a reply from the user. Not supported for messages sent on behalf of a business account
@@ -722,6 +726,8 @@ pub fn new_send_message_parameters(
     link_preview_options: None,
     disable_notification: None,
     protect_content: None,
+    allow_paid_broadcast: None,
+    message_effect_id: None,
     reply_parameters: None,
     reply_markup: None,
   )
@@ -777,6 +783,14 @@ pub fn encode_send_message_parameters(
     "protect_content",
     json.nullable(send_message_parameters.protect_content, json.bool),
   )
+  let allow_paid_broadcast = #(
+    "allow_paid_broadcast",
+    json.nullable(send_message_parameters.allow_paid_broadcast, json.bool),
+  )
+  let message_effect_id = #(
+    "message_effect_id",
+    json.nullable(send_message_parameters.message_effect_id, json.string),
+  )
   let reply_parameters = #(
     "reply_parameters",
     json.nullable(
@@ -799,6 +813,8 @@ pub fn encode_send_message_parameters(
     link_preview_options,
     disable_notification,
     protect_content,
+    allow_paid_broadcast,
+    message_effect_id,
     reply_parameters,
     reply_markup,
   ])

--- a/src/telega/reply.gleam
+++ b/src/telega/reply.gleam
@@ -76,6 +76,30 @@ pub fn with_poll(
   )
 }
 
+/// Use this method to send invoices.
+///
+/// **Official reference:** https://core.telegram.org/bots/api#sendinvoice
+pub fn with_invoice(
+  ctx ctx: Context(session),
+  title title: String,
+  description description: String,
+  payload payload: String,
+  currency currency: String,
+  prices prices: List(#(String, Int)),
+) {
+  api.send_invoice(
+    ctx.config.api,
+    parameters: model.new_send_invoice_parameters(
+      title: title,
+      description: description,
+      payload: payload,
+      currency: currency,
+      prices: prices,
+      chat_id: model.Stringed(ctx.key),
+    ),
+  )
+}
+
 /// Use this method to edit text and game messages.
 /// On success, if the edited message is not an inline message, the edited Message is returned, otherwise True is returned.
 ///

--- a/src/telega/reply.gleam
+++ b/src/telega/reply.gleam
@@ -58,6 +58,24 @@ pub fn with_dice(
   api.send_dice(ctx.config.api, parameters)
 }
 
+///  Use this method to send a native poll.
+///
+/// **Official reference:** https://core.telegram.org/bots/api#sendpoll
+pub fn with_poll(
+  ctx ctx: Context(session),
+  question question: String,
+  options options: List(String),
+) {
+  api.send_poll(
+    ctx.config.api,
+    parameters: model.new_send_poll_parameters(
+      question:,
+      options:,
+      chat_id: model.Stringed(ctx.key),
+    ),
+  )
+}
+
 /// Use this method to edit text and game messages.
 /// On success, if the edited message is not an inline message, the edited Message is returned, otherwise True is returned.
 ///


### PR DESCRIPTION
* Adds missing `sendMessage` options.
* Adds new commands: `sendPoll`,  `sendInvoice`, `createInvoiceLink`, `answerPreCheckoutQuery`
* Adds new update types: `Poll`, `PollAnswer`, and `PreCheckoutQuery`
* Adds other types used by the above: `InputPollOption`, `PollOption`, `OrderInfo`, and `ShippingAddress`

I plan to slowly chip away at [the list](https://github.com/bondiano/telega-gleam/issues/5), but will be prioritising the commands that I personally need.